### PR TITLE
FIX: TypeError: 'list' object is not callable

### DIFF
--- a/graph-structure-error/graph_structure_error.py
+++ b/graph-structure-error/graph_structure_error.py
@@ -31,7 +31,7 @@ def get_amrs(inp):
         dat.append(penman.decode(d))
     datg = [nx.DiGraph() for x in dat]
     for i,g in enumerate(dat):
-        for t in g.triples():
+        for t in g.triples:
             datg[i].add_edge(t[0],t[2],label=t[1])
     return datg
 


### PR DESCRIPTION
penman.graph.Graph.triple is a list and not a callable function, thus the proposed change.

Source: https://penman.readthedocs.io/en/latest/api/penman.graph.html#penman.graph.Graph.triples